### PR TITLE
[Cypress] Fix typos and minor mistakes in various tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhostABC:3000",
+  "baseUrl": "http://localhost:3000",
   "projectId": "7s5okt",
   "integrationFolder": "cypress/tests",
   "viewportHeight": 1000,

--- a/cypress/tests/ui/user-settings.spec.ts
+++ b/cypress/tests/ui/user-settings.spec.ts
@@ -5,7 +5,7 @@ describe("User Settings", function () {
   beforeEach(function () {
     cy.task("db:seed");
 
-    cy.intercept("PATCH", "/updateUsers/*").as("updateUser");
+    cy.intercept("PATCH", "/users/*").as("updateUser");
     cy.intercept("GET", "/notifications*").as("getNotifications");
 
     cy.database("find", "users").then((user: User) => {
@@ -68,7 +68,7 @@ describe("User Settings", function () {
     cy.getBySelLike("submit").should("not.be.disabled");
     cy.getBySelLike("submit").click();
 
-    cy.wait("@updateUser").its("response.statusCode").should("equal", 200);
+    cy.wait("@updateUser").its("response.statusCode").should("equal", 204);
 
     if (isMobile()) {
       cy.getBySel("sidenav-toggle").click();

--- a/cypress/tests/ui/user-settings.spec.ts
+++ b/cypress/tests/ui/user-settings.spec.ts
@@ -45,12 +45,12 @@ describe("User Settings", function () {
       .should("be.visible")
       .and("contain", "Must contain a valid email address");
 
-    cy.getBySelLike("phone-input").type("abc").clear().blur();
+    cy.getBySelLike("phoneNumber-input").type("abc").clear().blur();
     cy.get("#user-settings-phoneNumber-input-helper-text")
       .should("be.visible")
       .and("contain", "Enter a phone number");
 
-    cy.getBySelLike("phone-input").type("615-555-").blur();
+    cy.getBySelLike("phoneNumber-input").type("615-555-").blur();
     cy.get("#user-settings-phoneNumber-input-helper-text")
       .should("be.visible")
       .and("contain", "Phone number is not valid");
@@ -63,7 +63,7 @@ describe("User Settings", function () {
     cy.getBySelLike("firstName").clear().type("New First Name");
     cy.getBySelLike("lastName").clear().type("New Last Name");
     cy.getBySelLike("email").clear().type("email@email.com");
-    cy.getBySelLike("phone-input").clear().type("6155551212").blur();
+    cy.getBySelLike("phoneNumber-input").clear().type("6155551212").blur();
 
     cy.getBySelLike("submit").should("not.be.disabled");
     cy.getBySelLike("submit").click();


### PR DESCRIPTION
**Link Issue:**
Fixes #1 

**Summary:**
This PR includes three commits to resolve our current issues in CI with Cypress. The first fixes the baseUrl specified in the Cypress config. The second fixes a typo in User Settings suite with the phone input field selector. And the third fixes both a typo in the PATCH assertion in the User Settings suite as well as an HTTP code assertion.

**Post-merge are any additional actions required?**
Yes, we should ensure CI is green across the board post-merge. This PR is expected to fix all new failures from last night.

**Signed Off y/n:**
Yes